### PR TITLE
Link groups to deployments

### DIFF
--- a/app/admin/group.rb
+++ b/app/admin/group.rb
@@ -1,21 +1,21 @@
 ActiveAdmin.register Group do
   menu priority: 4, label: "Groups"
 
-  permit_params :name, :development, :description
+  permit_params :name, :deployment_id, :description
 
   index do
     selectable_column
     id_column
     column :name
     column :description
-    column :development
+    column :deployment
     column :created_at
     column :updated_at
     actions
   end
 
   filter :name
-  filter :development
+  filter :deployment
   filter :created_at
   filter :updated_at
 
@@ -23,7 +23,7 @@ ActiveAdmin.register Group do
     f.inputs "Group Details" do
       f.input :name
       f.input :description
-      f.input :development
+      f.input :deployment
     end
     f.actions
   end
@@ -32,7 +32,7 @@ ActiveAdmin.register Group do
     attributes_table do
       row :name
       row :description
-      row :development
+      row :deployment
       row :created_at
       row :updated_at
     end

--- a/app/models/deployment.rb
+++ b/app/models/deployment.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 class Deployment < ApplicationRecord
   has_many :devices, dependent: :nullify
+  has_many :groups, dependent: :nullify
+
   validates :name, presence: true, uniqueness: true
 
   def title_with_prefix

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,3 +1,7 @@
 class Group < ActiveRecord::Base
+  belongs_to :deployment, optional: true
+
   has_many :devices
+
+  validates :name, presence: true
 end

--- a/db/migrate/20250903120000_replace_development_with_deployment_reference_in_groups.rb
+++ b/db/migrate/20250903120000_replace_development_with_deployment_reference_in_groups.rb
@@ -1,0 +1,6 @@
+class ReplaceDevelopmentWithDeploymentReferenceInGroups < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :groups, :development, :string
+    add_reference :groups, :deployment, foreign_key: true, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_09_02_152017) do
+ActiveRecord::Schema[7.0].define(version: 2025_09_03_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -116,8 +116,8 @@ ActiveRecord::Schema[7.0].define(version: 2025_09_02_152017) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "development"
-    t.index ["development"], name: "index_groups_on_development"
+    t.bigint "deployment_id"
+    t.index ["deployment_id"], name: "index_groups_on_deployment_id"
   end
 
   create_table "heartbeats", force: :cascade do |t|
@@ -165,6 +165,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_09_02_152017) do
   add_foreign_key "app_installations", "app_batch_installations"
   add_foreign_key "app_installations", "devices"
   add_foreign_key "app_usages", "devices"
+  add_foreign_key "groups", "deployments"
   add_foreign_key "devices", "groups"
   add_foreign_key "heartbeats", "devices"
   add_foreign_key "pkg_batch_installations", "pkgs"

--- a/spec/factories/deployments.rb
+++ b/spec/factories/deployments.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :deployment do
+    sequence(:name) { |n| "Deployment #{n}" }
+  end
+end

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :group do
+    sequence(:name) { |n| "Group #{n}" }
+    association :deployment
+  end
+end

--- a/spec/models/deployment_spec.rb
+++ b/spec/models/deployment_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe Deployment, type: :model do
+  subject { create(:deployment) }
+
+  it { should have_many(:devices).dependent(:nullify) }
+  it { should have_many(:groups).dependent(:nullify) }
+  it { should validate_presence_of(:name) }
+  it { should validate_uniqueness_of(:name) }
+end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe Group, type: :model do
+  it { should belong_to(:deployment).optional }
+  it { should have_many(:devices) }
+  it { should validate_presence_of(:name) }
+end


### PR DESCRIPTION
## Summary
- add deployment association to groups and remove legacy development column
- allow deployments to own groups
- cover Group–Deployment link with model specs and factories

## Testing
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*
- `bundle exec rails db:migrate` *(fails: command not found: rails)*
- `bundle exec rspec` *(fails: command not found: rspec)*


------
https://chatgpt.com/codex/tasks/task_e_68b6c4a3d6688333b8619e58444ac7c7