### PR TITLE
Expose deployment groups and restrict cross-deployment assignments

### DIFF
--- a/app/admin/deployments.rb
+++ b/app/admin/deployments.rb
@@ -60,6 +60,18 @@ ActiveAdmin.register Deployment do
           column(:show) { |d| link_to "View", admin_device_path(d) }
         end
       end
+
+      tab "Device Groups" do
+        table_for resource.groups do
+          column(:name) { |g| link_to g.name, admin_group_path(g) }
+          column :description
+          column("Devices") { |g| g.devices.count }
+        end
+
+        div do
+          link_to "Create Group for this Deployment", new_admin_group_path(deployment_id: resource.id), class: "button"
+        end
+      end
     end
   end
 end

--- a/app/admin/device.rb
+++ b/app/admin/device.rb
@@ -51,7 +51,12 @@ ActiveAdmin.register Device do
   end
 
   group_data = lambda do
-    groups = Group.order(:name).pluck(:name, :id)
+    dep_id = params.dig(:q, :deployment_id_eq)
+    groups = if dep_id.present?
+               Group.where(deployment_id: dep_id).order(:name).pluck(:name, :id)
+             else
+               []
+             end
     { "Group Name" => groups }
   end
 

--- a/app/admin/group.rb
+++ b/app/admin/group.rb
@@ -28,6 +28,11 @@ ActiveAdmin.register Group do
     f.actions
   end
 
+  action_item :back_to_deployment, only: [:show, :edit, :new] do
+    dep = resource.deployment || Deployment.find_by(id: params[:deployment_id])
+    link_to "Back to Deployment", admin_deployment_path(dep) if dep
+  end
+
   show do
     attributes_table do
       row :name
@@ -45,6 +50,14 @@ ActiveAdmin.register Group do
         column :os_version
         column :client_version
         column :created_at
+      end
+    end
+  end
+
+  controller do
+    def build_resource(*args)
+      super.tap do |group|
+        group.deployment_id ||= params[:deployment_id]
       end
     end
   end

--- a/spec/factories/admin_users.rb
+++ b/spec/factories/admin_users.rb
@@ -1,6 +1,7 @@
 FactoryGirl.define do
   factory :admin_user do
-    
+    sequence(:email) { |n| "admin#{n}@example.com" }
+    password { "password" }
   end
 
 end

--- a/spec/requests/admin/deployment_groups_spec.rb
+++ b/spec/requests/admin/deployment_groups_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin deployment groups', type: :request do
+  let(:admin) { create(:admin_user, email: 'admin@example.com', password: 'password') }
+
+  before do
+    post admin_user_session_path, params: { admin_user: { email: admin.email, password: 'password' } }
+  end
+
+  it 'shows device groups for deployment' do
+    deployment = create(:deployment, name: 'Main Deployment')
+    group = create(:group, deployment: deployment, name: 'Group A', description: 'Test group')
+    create(:device, deployment: deployment, group: group, unique_id: 'u1', gcm_token: 't1')
+
+    get admin_deployment_path(deployment)
+
+    expect(response.body).to include('Device Groups')
+    expect(response.body).to include('Group A')
+    expect(response.body).to include('Test group')
+  end
+end

--- a/spec/requests/admin/device_group_assignment_spec.rb
+++ b/spec/requests/admin/device_group_assignment_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin device group assignment', type: :request do
+  let(:admin) { create(:admin_user, email: 'admin@example.com', password: 'password') }
+
+  before do
+    post admin_user_session_path, params: { admin_user: { email: admin.email, password: 'password' } }
+  end
+
+  it 'assigns selected devices to a group' do
+    deployment = create(:deployment)
+    group = create(:group, deployment: deployment, name: 'Group B')
+    device = create(:device, deployment: deployment, unique_id: 'u1', gcm_token: 't1')
+
+    post batch_action_admin_devices_path, params: {
+      batch_action: 'assign_group',
+      'Group Name' => group.id,
+      collection_selection: [device.id]
+    }
+
+    expect(response).to redirect_to(admin_devices_path)
+    expect(device.reload.group).to eq(group)
+  end
+end


### PR DESCRIPTION
## Summary
- Add “Device Groups” tab on deployment show page with links and group creation shortcut
- Prefill deployment in group form and provide easy navigation back to deployment
- Limit group batch assignment to groups within selected deployment
- Add request specs for deployment group listing and group assignment

## Testing
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*
- `bundle exec rspec spec/requests/admin/deployment_groups_spec.rb spec/requests/admin/device_group_assignment_spec.rb` *(fails: bundler: command not found: rspec)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f2dfb0e88333a51248cfa6982e62