### PR TITLE
Add OTA package lookup for deployments

### DIFF
--- a/app/admin/deployments.rb
+++ b/app/admin/deployments.rb
@@ -34,10 +34,15 @@ ActiveAdmin.register Deployment do
 
     tabs do
       tab "OTA Packages" do
-        table_for resource.pkgs do
-          column(:name) { |pkg| link_to pkg.name, admin_pkg_path(pkg) }
-          column :finger_print
-          column :created_at
+        pkgs = resource.ota_packages
+        if pkgs.exists?
+          table_for pkgs do
+            column(:name) { |pkg| link_to pkg.name, admin_pkg_path(pkg) }
+            column :finger_print
+            column :created_at
+          end
+        else
+          status_tag "No OTA packages found", :warning
         end
 
         div do

--- a/app/models/deployment.rb
+++ b/app/models/deployment.rb
@@ -12,4 +12,14 @@ class Deployment < ApplicationRecord
       name
     end
   end
+
+  def ota_packages
+    sample_fp = devices.where.not(finger_print: [nil, ""]).limit(1).pluck(:finger_print).first
+    return Pkg.none if sample_fp.blank?
+
+    prefix = sample_fp.split(":").first
+    return Pkg.none if prefix.blank?
+
+    Pkg.where("finger_print LIKE ?", "#{prefix}%")
+  end
 end


### PR DESCRIPTION
## Summary
- add `Deployment#ota_packages` to query packages matching device fingerprint prefixes
- show OTA packages based on `ota_packages` and warn when none

## Testing
- `bundle exec rspec` *(fails: bundler: command not found: rspec; bundle install 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b7fd77bd888333987e23d31883b231